### PR TITLE
Update AddonBase.cs

### DIFF
--- a/Host.Domain/AddonBase.cs
+++ b/Host.Domain/AddonBase.cs
@@ -2,11 +2,8 @@
 
 namespace Host.Domain
 {
-    public class AddonBase : IAddon
+    public abstract class AddonBase : IAddon
     {
-        public void Run()
-        {
-
-        }
+        public abstract void Run();
     }
 }


### PR DESCRIPTION
If AddonBase should not be used as is, may be better to change the class to abstract and the `Run` method to virtual, which allows for empty "Run"s to be kept not overriden